### PR TITLE
Support env overrides in tests

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,86 +1,25 @@
-import {
-  describe, test, expect, vi, beforeEach, afterEach,
-  Mock,
-} from 'vitest';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { AirtableMCPServer } from './mcpServer.js';
+import { describe, test, expect, vi, afterEach } from 'vitest';
 
-// Mock the required modules
-vi.mock('./mcpServer.js');
+// Ensure fresh module each time
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
 
-describe('Main Application', () => {
-  // Save original argv
-  const originalArgv = process.argv;
-  const originalEnv = process.env;
-
-  beforeEach(() => {
-    // Reset mocks before each test
-    vi.clearAllMocks();
-
-    // Reset process.argv
-    process.argv = originalArgv;
-    process.env = originalEnv;
+describe('index entry', () => {
+  test('throws when required env vars are missing', async () => {
+    vi.stubEnv('VITEST', 'true');
+    await expect(import('./index.js')).rejects.toThrow('Missing AIRTABLE_API_KEY');
   });
 
-  test('exits with error when no API key is provided', async () => {
-    // Set argv to simulate no arguments
-    process.argv = ['node', 'index.js'];
-    process.env = {};
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  test('loads with provided env vars', async () => {
+    vi.stubEnv('VITEST', 'true');
+    vi.stubEnv('AIRTABLE_API_KEY', 'key');
+    vi.stubEnv('AIRTABLE_BASE_ID', 'base');
+    vi.stubEnv('AIRTABLE_TABLE_NAME', 'table');
+    vi.stubEnv('AIRTABLE_VIEW_ID', 'view');
 
-    // Import the module and give it a chance to run
-    await import('./index.js');
-    await new Promise<void>((resolve) => {
-      setTimeout(() => resolve(), 100);
-    });
-
-    // Verify it tried to exit with error
-    expect(mockExit).toHaveBeenCalledWith(1);
-    mockExit.mockRestore();
-  });
-
-  test('creates services and connects server with valid API key from command line', async () => {
-    // Set argv to simulate valid API key argument
-    process.argv = ['node', 'index.js', 'test-api-key'];
-    process.env = {};
-
-    // Mock the connect method
-    const mockConnect = vi.fn();
-    (AirtableMCPServer as Mock).mockImplementation(() => ({
-      connect: mockConnect,
-    }));
-
-    // Import and execute main
-    await import('./index.js');
-
-    // Verify service creation and connection
-    expect(AirtableMCPServer).toHaveBeenCalled();
-    expect(mockConnect.mock.calls[0][0]).toBeInstanceOf(StdioServerTransport);
-  });
-
-  test('creates services and connects server with valid API key from environment', async () => {
-    // Set argv to simulate valid API key argument
-    process.argv = ['node', 'index.js'];
-    process.env = { AIRTABLE_API_KEY: 'test-api-key' };
-
-    // Mock the connect method
-    const mockConnect = vi.fn();
-    (AirtableMCPServer as Mock).mockImplementation(() => ({
-      connect: mockConnect,
-    }));
-
-    // Import and execute main
-    await import('./index.js');
-
-    // Verify service creation and connection
-    expect(AirtableMCPServer).toHaveBeenCalled();
-    expect(mockConnect.mock.calls[0][0]).toBeInstanceOf(StdioServerTransport);
-  });
-
-  // Cleanup
-  afterEach(() => {
-    process.argv = originalArgv;
-    process.env = originalEnv;
-    vi.resetModules();
+    const mod = await import('./index.js');
+    expect(mod.default).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- start Express app only outside tests and export the instance
- use env values in `index.ts` and gate required checks
- rewrite `index.test.ts` with `vi.stubEnv` to provide mocked env vars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6876ee901d44833187fd0a9ab4ae9131